### PR TITLE
fix(cli): error when building with vite

### DIFF
--- a/packages/varlet-ui/types/locale.d.ts
+++ b/packages/varlet-ui/types/locale.d.ts
@@ -35,6 +35,7 @@ interface Locale {
   add(lang: string, pack: Partial<Pack>): void
   use(lang: string): void
   merge(lang: string, pack: Partial<Pack>): void
+  new(params:any):Locale
 }
 
 export const Locale: Locale


### PR DESCRIPTION
Fix bug generated by building in projects using vite and typescript.

"Type 'Locale' is not a constructor function type"

![image](https://user-images.githubusercontent.com/42365251/140673330-631d95d6-5551-4c58-8d4d-6ae38380a052.png)
