### PR TITLE
fix(ui/menu): reslove error of getting offsetHeight when alignment is…

### DIFF
--- a/packages/varlet-ui/src/menu/Menu.vue
+++ b/packages/varlet-ui/src/menu/Menu.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, watch, onMounted, onUnmounted } from 'vue'
+import { defineComponent, ref, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import { props } from './props'
 import { getLeft, getTop, toSizeUnit } from '../utils/elements'
 import { useZIndex } from '../context/zIndex'
@@ -67,8 +67,10 @@ export default defineComponent({
 
     // expose
     const resize = () => {
-      top.value = computeTop(props.alignment)
-      left.value = getLeft(host.value as HTMLElement)
+      nextTick(() => {
+        top.value = computeTop(props.alignment)
+        left.value = getLeft(host.value as HTMLElement)
+      })
     }
 
     watch(() => props.alignment, resize)

--- a/packages/varlet-ui/src/menu/Menu.vue
+++ b/packages/varlet-ui/src/menu/Menu.vue
@@ -67,10 +67,8 @@ export default defineComponent({
 
     // expose
     const resize = () => {
-      nextTick(() => {
-        top.value = computeTop(props.alignment)
-        left.value = getLeft(host.value as HTMLElement)
-      })
+      top.value = computeTop(props.alignment)
+      left.value = getLeft(host.value as HTMLElement)
     }
 
     watch(() => props.alignment, resize)
@@ -79,7 +77,10 @@ export default defineComponent({
       () => props.show,
       async (newValue: boolean) => {
         const { onOpen, onClose } = props
-        newValue && resize()
+        if (newValue) {
+          await nextTick()
+          resize()
+        }
         newValue ? onOpen?.() : onClose?.()
       }
     )


### PR DESCRIPTION
… set as bottom

## Checklist

---

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)

## Change information

---

当 menu 菜单的 alignment 属性设置为 bottom，
在计算 top 时获取 menu 元素 offsetHeight 为 0，导致属性失效；
经猜测原因大概是由于获取时元素为不可见状态，故采用了 nextTick API 来解决